### PR TITLE
Adjust implementation for async connect method

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -52,7 +52,8 @@ let package = Package(
                 .product(name: "Spezi", package: "Spezi")
             ],
             swiftSettings: [
-                swiftConcurrency
+                swiftConcurrency,
+                .enableUpcomingFeature("InferSendableFromCaptures")
             ],
             plugins: [] + swiftLintPlugin()
         ),
@@ -68,7 +69,8 @@ let package = Package(
                 .process("Resources")
             ],
             swiftSettings: [
-                swiftConcurrency
+                swiftConcurrency,
+                .enableUpcomingFeature("InferSendableFromCaptures")
             ],
             plugins: [] + swiftLintPlugin()
         ),
@@ -83,7 +85,8 @@ let package = Package(
                 .process("Resources")
             ],
             swiftSettings: [
-                swiftConcurrency
+                swiftConcurrency,
+                .enableUpcomingFeature("InferSendableFromCaptures")
             ],
             plugins: [] + swiftLintPlugin()
         ),
@@ -98,7 +101,8 @@ let package = Package(
                 .product(name: "XCTestExtensions", package: "XCTestExtensions")
             ],
             swiftSettings: [
-                swiftConcurrency
+                swiftConcurrency,
+                .enableUpcomingFeature("InferSendableFromCaptures")
             ],
             plugins: [] + swiftLintPlugin()
         ),
@@ -111,7 +115,8 @@ let package = Package(
                 .product(name: "XCTestExtensions", package: "XCTestExtensions")
             ],
             swiftSettings: [
-                swiftConcurrency
+                swiftConcurrency,
+                .enableUpcomingFeature("InferSendableFromCaptures")
             ],
             plugins: [] + swiftLintPlugin()
         )

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "1.1.1"),
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.4.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.5.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", exact: "3.0.0-beta.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", exact: "3.0.0-beta.2"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "2.1.1"),
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", .upToNextMinor(from: "0.4.12"))
     ] + swiftLintPackage(),

--- a/Sources/SpeziDevices/PairedDevices.swift
+++ b/Sources/SpeziDevices/PairedDevices.swift
@@ -336,7 +336,15 @@ public final class PairedDevices: @unchecked Sendable {
 
         pendingConnectionAttempts[device.id] = Task {
             await previousTask?.value // make sure its ordered
-            await device.connect()
+            do {
+                try await device.connect()
+            } catch {
+                guard !Task.isCancelled else {
+                    return
+                }
+                logger.warning("Failed connection attempt for device \(device.label). Retrying ...")
+                connectionAttempt(for: device)
+            }
         }
     }
 
@@ -394,27 +402,49 @@ extension PairedDevices {
             throw DevicePairingError.invalidState
         }
 
-        await device.connect()
-
         let id = device.id
-        let timeoutHandler = { @Sendable @MainActor in
-            _ = self.ongoingPairings.removeValue(forKey: id)?.signalTimeout()
+
+        try await withThrowingDiscardingTaskGroup { group in
+            // timeout task
+            group.addTask {
+                await withTimeout(of: timeout) { @MainActor in
+                    _ = self.ongoingPairings.removeValue(forKey: id)?.signalTimeout()
+                }
+            }
+
+            // connect task
+            group.addTask { @MainActor in
+                do {
+                    try await device.connect()
+                } catch {
+                    if error is CancellationError {
+                        self.ongoingPairings.removeValue(forKey: id)?.signalCancellation()
+                    }
+
+                    throw error
+                }
+            }
+
+            // pairing task
+            group.addTask { @MainActor in
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        self.ongoingPairings[id] = PairingContinuation(continuation)
+                    }
+                } onCancel: {
+                    Task { @MainActor [weak device] in
+                        self.ongoingPairings.removeValue(forKey: id)?.signalCancellation()
+                        await device?.disconnect()
+                    }
+                }
+            }
         }
 
-        async let _ = withTimeout(of: timeout, perform: timeoutHandler)
-
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { continuation in
-                ongoingPairings[id] = PairingContinuation(continuation)
-            }
-        } onCancel: {
-            Task { @MainActor [weak device] in
-                ongoingPairings.removeValue(forKey: id)?.signalCancellation()
-                await device?.disconnect()
-            }
+        // the task group above should exit with a CancellationError anyways, but safe to double check here
+        guard !Task.isCancelled else {
+            throw CancellationError()
         }
 
-        // if cancelled the continuation throws an CancellationError
         await registerPairedDevice(device)
     }
 

--- a/Sources/SpeziDevices/PairedDevices.swift
+++ b/Sources/SpeziDevices/PairedDevices.swift
@@ -438,6 +438,7 @@ extension PairedDevices {
             }
         }
 
+
         // the task group above should exit with a CancellationError anyways, but safe to double check here
         guard !Task.isCancelled else {
             throw CancellationError()

--- a/Tests/SpeziDevicesTests/PairedDevicesTests.swift
+++ b/Tests/SpeziDevicesTests/PairedDevicesTests.swift
@@ -83,7 +83,7 @@ final class PairedDevicesTests: XCTestCase {
         }()
 
 
-        await device.connect()
+        try await device.connect()
         try await Task.sleep(for: .seconds(1.1))
         XCTAssertEqual(device.state, .connected)
 
@@ -113,7 +113,7 @@ final class PairedDevicesTests: XCTestCase {
         }
         device.$nearby.inject(true)
 
-        await device.connect()
+        try await device.connect()
         try await XCTAssertThrowsErrorAsync(await devices.pair(with: device)) { error in
             XCTAssertEqual(try XCTUnwrap(error as? DevicePairingError), .invalidState)
         }

--- a/Tests/UITests/TestApp/BluetoothViewsTest.swift
+++ b/Tests/UITests/TestApp/BluetoothViewsTest.swift
@@ -41,7 +41,7 @@ struct BluetoothViewsTest: View {
         Task {
             switch device.state {
             case .disconnected, .disconnecting:
-                await device.connect()
+                try await device.connect()
             case .connecting, .connected:
                 await device.disconnect()
             }

--- a/Tests/UITests/TestApp/DevicesTestView.swift
+++ b/Tests/UITests/TestApp/DevicesTestView.swift
@@ -48,9 +48,9 @@ struct DevicesTestView: View {
                             device.$advertisementData.inject(AdvertisementData()) // trigger onChange advertisement
                         }
                         AsyncButton {
-                            await device.connect()
-                            await weightScale.connect()
-                            await bloodPressureCuff.connect()
+                            try await device.connect()
+                            try await weightScale.connect()
+                            try await bloodPressureCuff.connect()
                         } label: {
                             Label("Connect", systemImage: "cable.connector")
                         }

--- a/Tests/UITests/TestApp/DevicesTestView.swift
+++ b/Tests/UITests/TestApp/DevicesTestView.swift
@@ -38,6 +38,8 @@ struct DevicesTestView: View {
     @State private var weightScale = OmronWeightScale.createMockDevice(manufacturerData: .omronManufacturerData(mode: .transferMode))
     @State private var bloodPressureCuff = OmronBloodPressureCuff.createMockDevice(manufacturerData: .omronManufacturerData(mode: .transferMode))
 
+    @State private var viewState: ViewState = .idle
+
     var body: some View {
         NavigationStack {
             DevicesView(appName: "Example", pairingHint: "Enable pairing mode on the device.")
@@ -47,7 +49,7 @@ struct DevicesTestView: View {
                             device.isInPairingMode = true
                             device.$advertisementData.inject(AdvertisementData()) // trigger onChange advertisement
                         }
-                        AsyncButton {
+                        AsyncButton(state: $viewState) {
                             try await device.connect()
                             try await weightScale.connect()
                             try await bloodPressureCuff.connect()
@@ -97,6 +99,7 @@ struct DevicesTestView: View {
                 )
                 didRegister = true
             }
+            .viewStateAlert(state: $viewState)
     }
 }
 

--- a/Tests/UITests/TestApp/DevicesTestView.swift
+++ b/Tests/UITests/TestApp/DevicesTestView.swift
@@ -79,6 +79,7 @@ struct DevicesTestView: View {
                     }
                 }
         }
+            .viewStateAlert(state: $viewState)
             .onAppear {
                 guard !didRegister else {
                     return
@@ -99,7 +100,6 @@ struct DevicesTestView: View {
                 )
                 didRegister = true
             }
-            .viewStateAlert(state: $viewState)
     }
 }
 

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -34,6 +34,34 @@
                ReferencedContainer = "container:UITests.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SpeziOmron"
+               BuildableName = "SpeziOmron"
+               BlueprintName = "SpeziOmron"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SpeziDevicesUI"
+               BuildableName = "SpeziDevicesUI"
+               BlueprintName = "SpeziDevicesUI"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
# Adjust implementation for async connect method

## :recycle: Current situation & Problem
The latest beta release of SpeziBluetooth changed the peripherals connect method to be async throws allowing use to await till the device is fully connected and propagating any connection errors. This requires some slight modifications to SpeziDevices resolved with this PR.

## :gear: Release Notes 
* Update to SpeziBluetooth 3.0 Beta 2

## :books: Documentation
-- 


## :white_check_mark: Testing
Verified against existing test suite.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
