### PR TITLE
Fix duplicated delivery of Omron Measurements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.5.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", branch: "feature/concurrency-improvements"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", from: "3.0.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "2.1.1"),
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions", .upToNextMinor(from: "0.4.12"))
     ] + swiftLintPackage(),

--- a/Package.swift
+++ b/Package.swift
@@ -135,7 +135,7 @@ func swiftLintPlugin() -> [Target.PluginUsage] {
 
 func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
     if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
-        [.package(url: "https://github.com/realm/SwiftLint.git", .upToNextMinor(from: "0.55.1"))]
+        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.1")]
     } else {
         []
     }

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-collections", from: "1.1.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.1"),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", branch: "feature/upgrade-spezi"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.5.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", branch: "feature/concurrency-improvements"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "2.1.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -32,13 +32,13 @@ let package = Package(
         .library(name: "SpeziOmron", targets: ["SpeziOmron"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "1.1.1"),
-        .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.4.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.5.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", exact: "3.0.0-beta.2"),
+        .package(url: "https://github.com/apple/swift-collections", from: "1.1.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", branch: "feature/upgrade-spezi"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.5.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", branch: "feature/concurrency-improvements"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "2.1.1"),
-        .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", .upToNextMinor(from: "0.4.12"))
+        .package(url: "https://github.com/StanfordBDHG/XCTestExtensions", .upToNextMinor(from: "0.4.12"))
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Sources/SpeziDevices/Health/BloodPressureMeasurement+HKSample.swift
+++ b/Sources/SpeziDevices/Health/BloodPressureMeasurement+HKSample.swift
@@ -85,7 +85,15 @@ extension BloodPressureMeasurement {
 extension HKCorrelation {
     /// Retrieve a mock blood pressure sample.
     @_spi(TestingSupport) public static var mockBloodPressureSample: HKCorrelation {
-        let measurement = BloodPressureMeasurement(systolic: 117, diastolic: 76, meanArterialPressure: 67, unit: .mmHg, pulseRate: 68)
+        let dateTime = DateTime(from: .now)
+        let measurement = BloodPressureMeasurement(
+            systolic: 117,
+            diastolic: 76,
+            meanArterialPressure: 67,
+            unit: .mmHg,
+            timeStamp: dateTime,
+            pulseRate: 68
+        )
         guard let sample = measurement.bloodPressureSample(source: nil) else {
             preconditionFailure("Mock sample was unexpectedly invalid!")
         }
@@ -96,7 +104,15 @@ extension HKCorrelation {
 extension HKQuantitySample {
     /// Retrieve a mock heart rate sample.
     @_spi(TestingSupport) public static var mockHeartRateSample: HKQuantitySample {
-        let measurement = BloodPressureMeasurement(systolic: 117, diastolic: 76, meanArterialPressure: 67, unit: .mmHg, pulseRate: 68)
+        let dateTime = DateTime(from: .now)
+        let measurement = BloodPressureMeasurement(
+            systolic: 117,
+            diastolic: 76,
+            meanArterialPressure: 67,
+            unit: .mmHg,
+            timeStamp: dateTime,
+            pulseRate: 68
+        )
         guard let sample = measurement.heartRateSample(source: nil) else {
             preconditionFailure("Mock sample was unexpectedly invalid!")
         }

--- a/Sources/SpeziDevices/HealthMeasurements.swift
+++ b/Sources/SpeziDevices/HealthMeasurements.swift
@@ -102,7 +102,7 @@ public final class HealthMeasurements: @unchecked Sendable {
     /// To clear pending measurements call ``discardMeasurement(_:)``.
     @MainActor public private(set) var pendingMeasurements: [HealthKitMeasurement] = []
 
-    @Dependency @ObservationIgnored private var bluetooth: Bluetooth?
+    @Dependency(Bluetooth.self) @ObservationIgnored private var bluetooth: Bluetooth?
 
     private var modelContainer: ModelContainer?
 
@@ -138,8 +138,8 @@ public final class HealthMeasurements: @unchecked Sendable {
         }
 
 
-        Task.detached { @MainActor in
-            self.fetchMeasurements()
+        Task.detached {
+            await self.fetchMeasurements()
         }
     }
 
@@ -155,7 +155,8 @@ public final class HealthMeasurements: @unchecked Sendable {
         on keyPath: WeightScaleKeyPath<Device>
     ) {
         device[keyPath: keyPath].$weightMeasurement.onChange { @MainActor [weak self, weak device] measurement in
-            guard let self, let device else {
+            guard let self, let device, case .connected = device.state else {
+                // TODO: we now just assume connected for all devices?
                 return
             }
             let service = device[keyPath: keyPath]

--- a/Sources/SpeziDevices/HealthMeasurements.swift
+++ b/Sources/SpeziDevices/HealthMeasurements.swift
@@ -156,7 +156,6 @@ public final class HealthMeasurements: @unchecked Sendable {
     ) {
         device[keyPath: keyPath].$weightMeasurement.onChange { @MainActor [weak self, weak device] measurement in
             guard let self, let device, case .connected = device.state else {
-                // TODO: we now just assume connected for all devices?
                 return
             }
             let service = device[keyPath: keyPath]
@@ -180,7 +179,6 @@ public final class HealthMeasurements: @unchecked Sendable {
         // make sure to not capture the device
         device[keyPath: keyPath].$bloodPressureMeasurement.onChange { @MainActor [weak self, weak device] measurement in
             guard let self, let device, case .connected = device.state else {
-                // TODO: we now just assume connected for all devices?
                 return
             }
             let service = device[keyPath: keyPath]

--- a/Sources/SpeziDevices/HealthMeasurements.swift
+++ b/Sources/SpeziDevices/HealthMeasurements.swift
@@ -167,7 +167,6 @@ public final class HealthMeasurements: @unchecked Sendable {
             logger.debug("Received new weight measurement: \(String(describing: measurement))")
             handleNewMeasurement(.weight(measurement, service.features ?? []), from: device.hkDevice)
         }
-        // TODO: PLSS. support showing time in the sheet!
     }
 
     /// Configure receiving and processing blood pressure measurements form the provided service.

--- a/Sources/SpeziDevices/HealthMeasurements.swift
+++ b/Sources/SpeziDevices/HealthMeasurements.swift
@@ -155,9 +155,14 @@ public final class HealthMeasurements: @unchecked Sendable {
         on keyPath: WeightScaleKeyPath<Device>
     ) {
         device[keyPath: keyPath].$weightMeasurement.onChange { @MainActor [weak self, weak device] measurement in
-            guard let self, let device, case .connected = device.state else {
+            guard let self, let device else {
                 return
             }
+            guard case .connected = device.state else {
+                logger.debug("Ignored weight measurement that was received while connecting: \(String(describing: measurement))")
+                return
+            }
+            
             let service = device[keyPath: keyPath]
             logger.debug("Received new weight measurement: \(String(describing: measurement))")
             handleNewMeasurement(.weight(measurement, service.features ?? []), from: device.hkDevice)
@@ -178,7 +183,11 @@ public final class HealthMeasurements: @unchecked Sendable {
     ) {
         // make sure to not capture the device
         device[keyPath: keyPath].$bloodPressureMeasurement.onChange { @MainActor [weak self, weak device] measurement in
-            guard let self, let device, case .connected = device.state else {
+            guard let self, let device else {
+                return
+            }
+            guard case .connected = device.state else {
+                logger.debug("Ignored blood pressure measurement that was received while connecting: \(String(describing: measurement))")
                 return
             }
             let service = device[keyPath: keyPath]

--- a/Sources/SpeziDevices/HealthMeasurements.swift
+++ b/Sources/SpeziDevices/HealthMeasurements.swift
@@ -163,6 +163,7 @@ public final class HealthMeasurements: @unchecked Sendable {
             logger.debug("Received new weight measurement: \(String(describing: measurement))")
             handleNewMeasurement(.weight(measurement, service.features ?? []), from: device.hkDevice)
         }
+        // TODO: PLSS. support showing time in the sheet!
     }
 
     /// Configure receiving and processing blood pressure measurements form the provided service.
@@ -178,7 +179,8 @@ public final class HealthMeasurements: @unchecked Sendable {
     ) {
         // make sure to not capture the device
         device[keyPath: keyPath].$bloodPressureMeasurement.onChange { @MainActor [weak self, weak device] measurement in
-            guard let self, let device else {
+            guard let self, let device, case .connected = device.state else {
+                // TODO: we now just assume connected for all devices?
                 return
             }
             let service = device[keyPath: keyPath]

--- a/Sources/SpeziDevices/Measurements/HealthKitMeasurement.swift
+++ b/Sources/SpeziDevices/Measurements/HealthKitMeasurement.swift
@@ -15,6 +15,16 @@ public enum HealthKitMeasurement {
     case weight(HKQuantitySample, bmi: HKQuantitySample? = nil, height: HKQuantitySample? = nil)
     /// A blood pressure correlation with an optional heart rate sample.
     case bloodPressure(HKCorrelation, heartRate: HKQuantitySample? = nil)
+
+    /// The start date of the primary sample
+    public var startDate: Date {
+        switch self {
+        case let .weight(sample, _, _):
+            sample.startDate
+        case let .bloodPressure(correlation, _):
+            correlation.startDate
+        }
+    }
 }
 
 

--- a/Sources/SpeziDevices/PairedDevices.swift
+++ b/Sources/SpeziDevices/PairedDevices.swift
@@ -163,7 +163,7 @@ public final class PairedDevices: @unchecked Sendable {
         }
 
         // We need to detach to not copy task local values
-        Task.detached { @MainActor in
+        Task.detached { @Sendable @MainActor in
             self.fetchAllPairedInfos()
 
             self.syncDeviceIcons() // make sure assets are up to date
@@ -294,8 +294,7 @@ public final class PairedDevices: @unchecked Sendable {
         }
 
         self.logger.info(
-            // TODO: it just shows "7 bytes", improve debugging!
-            "Detected nearby \(Device.self) accessory\(device.advertisementData.manufacturerData.map { " with manufacturer data \($0)" } ?? "")"
+            "Detected nearby \(Device.self) accessory\(device.advertisementData.manufacturerData.map { " with manufacturer data \($0.debugDescription)" } ?? "")"
         )
 
         discoveredDevices[device.id] = device
@@ -412,7 +411,7 @@ extension PairedDevices {
 
         try await withThrowingDiscardingTaskGroup { group in
             // connect task
-            group.addTask { @MainActor in
+            group.addTask { @Sendable @MainActor in
                 do {
                     try await device.connect()
                 } catch {
@@ -425,7 +424,7 @@ extension PairedDevices {
             }
 
             // pairing task
-            group.addTask { @MainActor in
+            group.addTask { @Sendable @MainActor in
                 try await withTaskCancellationHandler {
                     try await withCheckedThrowingContinuation { continuation in
                         self.ongoingPairings[id] = PairingContinuation(continuation)
@@ -665,7 +664,7 @@ extension PairedDevices {
 
         await withDiscardingTaskGroup { group in
             for deviceInfo in self._pairedDevices.values {
-                group.addTask { @MainActor in
+                group.addTask { @Sendable @MainActor in
                     guard self.peripherals[deviceInfo.id] == nil else {
                         return
                     }

--- a/Sources/SpeziDevices/PairedDevices.swift
+++ b/Sources/SpeziDevices/PairedDevices.swift
@@ -294,6 +294,7 @@ public final class PairedDevices: @unchecked Sendable {
         }
 
         self.logger.info(
+            // TODO: it just shows "7 bytes", improve debugging!
             "Detected nearby \(Device.self) accessory\(device.advertisementData.manufacturerData.map { " with manufacturer data \($0)" } ?? "")"
         )
 

--- a/Sources/SpeziDevices/PairedDevices.swift
+++ b/Sources/SpeziDevices/PairedDevices.swift
@@ -117,8 +117,8 @@ public final class PairedDevices: @unchecked Sendable {
 
     @Application(\.logger) @ObservationIgnored private var logger
 
-    @Dependency @ObservationIgnored private var bluetooth: Bluetooth?
-    @Dependency @ObservationIgnored private var tipKit: ConfigureTipKit
+    @Dependency(Bluetooth.self) @ObservationIgnored private var bluetooth: Bluetooth?
+    @Dependency(ConfigureTipKit.self) @ObservationIgnored private var tipKit
 
     private var modelContainer: ModelContainer?
 

--- a/Sources/SpeziDevices/Testing/MockDevice.swift
+++ b/Sources/SpeziDevices/Testing/MockDevice.swift
@@ -31,7 +31,7 @@ public final class MockDevice: PairableDevice, HealthDevice, BatteryPoweredDevic
     @Service public var bloodPressure = BloodPressureService()
     @Service public var weightScale = WeightScaleService()
 
-    @Dependency private var pairedDevices: PairedDevices?
+    @Dependency(PairedDevices.self) private var pairedDevices: PairedDevices?
 
     public var isInPairingMode: Bool = false
 

--- a/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
+++ b/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
@@ -123,11 +123,11 @@ public struct MeasurementsRecordedSheet: View {
                 return
             }
 
+            discardSelectedMeasurement(selectedMeasurement)
+
             if measurements.pendingMeasurements.isEmpty {
                 dismiss()
             }
-
-            discardSelectedMeasurement(selectedMeasurement)
         }
     }
 

--- a/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
+++ b/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
@@ -13,6 +13,28 @@ import SpeziViews
 import SwiftUI
 
 
+struct TimeSubheadline: View {
+    private let measurement: HealthKitMeasurement
+
+    var body: some View {
+        Group {
+            if Calendar.current.isDateInToday(measurement.startDate) {
+                Text("Today, \(Text(measurement.startDate, style: .time))")
+            } else {
+                Text(.now, style: .date) + Text(verbatim: ", ") + Text(.now, style: .time)
+            }
+        }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+    }
+
+    init(measurement: HealthKitMeasurement) {
+        self.measurement = measurement
+    }
+}
+
+
 /// A sheet view displaying one or many newly recorded measurements.
 ///
 /// This view retrieves the pending measurements from the [`HealthMeasurements`](https://swiftpackageindex.com/stanfordspezi/spezidevices/documentation/spezidevices/healthmeasurements)
@@ -54,6 +76,9 @@ public struct MeasurementsRecordedSheet: View {
                         Text("Measurement Recorded")
                             .font(.title)
                             .fixedSize(horizontal: false, vertical: true)
+                        if let selectedMeasurement {
+                            TimeSubheadline(measurement: selectedMeasurement)
+                        }
                     } subtitle: {
                         EmptyView()
                     } content: {

--- a/Sources/SpeziDevicesUI/Resources/Localizable.xcstrings
+++ b/Sources/SpeziDevicesUI/Resources/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings" : {
     "\"%@\" was successfully paired with the %@ app." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "„%1$@“ wurde erfolgreich zu der %2$@ App hinzugefügt."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -13,6 +19,12 @@
     },
     "%@, Searching" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@, Suchen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23,6 +35,12 @@
     },
     "%lld BPM" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld BPM"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33,6 +51,12 @@
     },
     "%lld cm" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld cm"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -43,6 +67,12 @@
     },
     "%lld/%lld mmHg" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld/%lld mmHg"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -53,6 +83,12 @@
     },
     "Accessory Paired" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zubehör Hinzugefügt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -63,6 +99,12 @@
     },
     "Add Device" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerät Hinzufügen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -73,6 +115,12 @@
     },
     "Battery" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batterie"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -83,6 +131,12 @@
     },
     "Bluetooth Failure" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth Fehler"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -93,6 +147,12 @@
     },
     "Bluetooth is required to make connections to nearby devices. ..." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth is erforderlich um sich mit Geräten in der Nähe zu verbinden. Bitte erlaube Bluetooth Verbindungen in deinen Privatsphäre Einstellungen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -103,6 +163,12 @@
     },
     "Bluetooth is turned off. ..." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth is ausgeschalten. Bitte schalte Bluetooth im Kontrollzentrum oder den Einstellungen ein, um dich mit einem Gerät zu verbinden."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -113,6 +179,12 @@
     },
     "Bluetooth is unsupported on this device!" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth is nicht unterstützt auf diesem Gerät!"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -123,6 +195,12 @@
     },
     "Bluetooth Off" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth Ausgeschalten"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -133,6 +211,12 @@
     },
     "Bluetooth Prohibited" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth Eingeschränkt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -143,6 +227,12 @@
     },
     "Bluetooth Unsupported" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth nicht unterstützt"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -153,6 +243,12 @@
     },
     "Cancel" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -163,6 +259,12 @@
     },
     "Connected" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbunden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -173,6 +275,12 @@
     },
     "Connecting" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinde"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -183,6 +291,12 @@
     },
     "Device Details" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geräte Details"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -193,6 +307,12 @@
     },
     "Devices" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geräte"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -203,6 +323,12 @@
     },
     "Discard" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwerfen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -213,6 +339,12 @@
     },
     "Disconnecting" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht verbunden"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -223,6 +355,12 @@
     },
     "Discovering" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suche"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -233,6 +371,12 @@
     },
     "Do you really want to forget this device?" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willst du dieses Gerät wirklich ignorieren?"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -243,6 +387,12 @@
     },
     "Do you want to pair %@ with the %@ app?" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willst du das Gerät %1$@ zur der %2$@ App hinzufügen?"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -253,6 +403,12 @@
     },
     "Done" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -263,6 +419,12 @@
     },
     "enter device name" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerätename"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -273,6 +435,12 @@
     },
     "Failed to pair accessory." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinzufügen des Zubehörs fehlgeschlagen."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -283,6 +451,12 @@
     },
     "Forget Device" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerät ignorieren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -293,6 +467,12 @@
     },
     "Forget This Device" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Gerät ignorieren"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -303,6 +483,12 @@
     },
     "Fully Unpair Device" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gerät vollständig Entkoppeln"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -313,6 +499,12 @@
     },
     "Intervention Required" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eingriff erforderlich"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -323,6 +515,12 @@
     },
     "Invalid Sample" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültige Messung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -333,6 +531,12 @@
     },
     "Make sure to to remove the device from the Bluetooth settings to fully unpair the device." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gehe in die Bluetooth Einstellungen, um das Geräte vollständig zu entkoppeln."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -343,6 +547,12 @@
     },
     "Measurement Recorded" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neue Messung"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -353,6 +563,12 @@
     },
     "Model" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -363,6 +579,12 @@
     },
     "Name" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -373,6 +595,12 @@
     },
     "No Devices" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Geräte"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -383,6 +611,12 @@
     },
     "No Pending Measurements" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine neuen Messungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -393,6 +627,12 @@
     },
     "OK" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -403,6 +643,12 @@
     },
     "Open Settings" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Öffne Einstellungen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -413,6 +659,12 @@
     },
     "Pair" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinzufügen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -423,6 +675,12 @@
     },
     "Pair Accessory" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zubehör hinzufügen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -433,6 +691,12 @@
     },
     "Pair New Device" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neues Gerät Hinzufügen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -443,6 +707,12 @@
     },
     "Paired devices will appear here once set up." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geräte, die du hinzugefügt hast, werden hier angezeigt."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -453,6 +723,12 @@
     },
     "Pairing Failed" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hinzufügen Fehlgeschlagen"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -463,6 +739,12 @@
     },
     "Requires Attention" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eingriff erforderlich"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -473,6 +755,12 @@
     },
     "Save" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichern"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -483,6 +771,12 @@
     },
     "Synchronizing ..." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronisiere ..."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -493,6 +787,12 @@
     },
     "The device name cannot be longer than 50 characters." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The Gerätename kann nicht länger als 50 Zeichen sein."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -503,6 +803,12 @@
     },
     "There are currently no pending measurements. Conduct a measurement with a paired device while nearby." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktuelle gibt es keine neuen Messungen. Stelle sicher, dass du dein Gerät benutzt während es in der Nähe ist."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -513,6 +819,12 @@
     },
     "This device was last seen at %@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieses Gerät wurde zuletzt gesehen um %@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -523,6 +835,12 @@
     },
     "This device was last seen on %@ at %@" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Geräte wurde zuletzt gesehen am %1$@ um %2$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
@@ -531,8 +849,30 @@
         }
       }
     },
+    "Today, %@" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heute, %@"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Today, %@"
+          }
+        }
+      }
+    },
     "We have trouble with the Bluetooth communication. Please try again." : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Es gab Probleme mit der Bluetooth Kommunikation. Bitte versuche es erneut."
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",

--- a/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
+++ b/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
@@ -96,18 +96,20 @@ public final class OmronBloodPressureCuff: BluetoothDevice, Identifiable, OmronH
 
     @SpeziBluetooth
     private func handleCurrentTimeChange(_ time: CurrentTime) async {
-        guard case .connected = state else {
-            logger.debug("Ignoring updated device time for \(self.label) that was received while connecting: \(String(describing: time))")
-            return
-        }
         logger.debug("Received updated device time for \(self.label) is \(String(describing: time))")
 
-        // for Omron we take that as a signal that device is paired
-        await pairedDevices?.signalDevicePaired(self)
-
+        // We always update time on the first current time notification. That's how it is expected for Omron devices.
+        // First time notification might come before we are considered fully connected (from SpeziBluetooth point of view).
+        // However, this will trigger another notification anyways, which will then arrive once we are connected
+        // and the iOS Bluetooth Pairing dialog was dismissed.
         if !didReceiveFirstTimeNotification {
             didReceiveFirstTimeNotification = true
             self.time.synchronizeDeviceTime()
+        }
+
+        if case .connected = state {
+            // for Omron we take that as a signal that device is paired
+            await pairedDevices?.signalDevicePaired(self)
         }
     }
 }

--- a/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
+++ b/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
@@ -104,7 +104,11 @@ public final class OmronBloodPressureCuff: BluetoothDevice, Identifiable, OmronH
         // and the iOS Bluetooth Pairing dialog was dismissed.
         if !didReceiveFirstTimeNotification {
             didReceiveFirstTimeNotification = true
-            self.time.synchronizeDeviceTime()
+            do {
+                try await self.time.synchronizeDeviceTime()
+            } catch {
+                logger.warning("Failed to update current time: \(error)")
+            }
         }
 
         if case .connected = state {

--- a/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
+++ b/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
@@ -96,6 +96,10 @@ public final class OmronBloodPressureCuff: BluetoothDevice, Identifiable, OmronH
 
     @SpeziBluetooth
     private func handleCurrentTimeChange(_ time: CurrentTime) async {
+        guard case .connected = state else {
+            logger.debug("Ignoring updated device time for \(self.label) that was received while connecting: \(String(describing: time))")
+            return
+        }
         logger.debug("Received updated device time for \(self.label) is \(String(describing: time))")
 
         // for Omron we take that as a signal that device is paired

--- a/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
+++ b/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
@@ -50,8 +50,8 @@ public final class OmronBloodPressureCuff: BluetoothDevice, Identifiable, OmronH
     @DeviceAction(\.connect) public var connect
     @DeviceAction(\.disconnect) public var disconnect
 
-    @Dependency private var measurements: HealthMeasurements?
-    @Dependency private var pairedDevices: PairedDevices?
+    @Dependency(HealthMeasurements.self) private var measurements: HealthMeasurements?
+    @Dependency(PairedDevices.self) private var pairedDevices: PairedDevices?
 
     /// Initialize the device.
     public required init() {}
@@ -77,6 +77,7 @@ public final class OmronBloodPressureCuff: BluetoothDevice, Identifiable, OmronH
     }
 
     private func handleStateChange(_ state: PeripheralState) async {
+        logger.debug("\(Self.self) changed state to \(state).")
         if case .connected = state,
            case .transferMode = manufacturerData?.pairingMode {
             time.synchronizeDeviceTime()

--- a/Sources/SpeziOmron/Devices/OmronWeightScale.swift
+++ b/Sources/SpeziOmron/Devices/OmronWeightScale.swift
@@ -74,8 +74,6 @@ public final class OmronWeightScale: BluetoothDevice, Identifiable, OmronHealthD
         }
     }
 
-    // TODO: what happens with unhandeled responses in Omron state machine while subscribing to characteristics?
-
     @SpeziBluetooth
     private func handleCurrentTimeChange(_ time: CurrentTime) async {
         logger.debug("Received updated device time for \(self.label): \(String(describing: time))")
@@ -86,7 +84,11 @@ public final class OmronWeightScale: BluetoothDevice, Identifiable, OmronHealthD
         // and the iOS Bluetooth Pairing dialog was dismissed.
         if !didReceiveFirstTimeNotification {
             didReceiveFirstTimeNotification = true
-            self.time.synchronizeDeviceTime()
+            do {
+                try await self.time.synchronizeDeviceTime()
+            } catch {
+                logger.warning("Failed to update current time: \(error)")
+            }
         }
 
         if case .connected = state {

--- a/Sources/SpeziOmron/Devices/OmronWeightScale.swift
+++ b/Sources/SpeziOmron/Devices/OmronWeightScale.swift
@@ -64,6 +64,7 @@ public final class OmronWeightScale: BluetoothDevice, Identifiable, OmronHealthD
     }
 
     private func handleStateChange(_ state: PeripheralState) async {
+        logger.debug("\(Self.self) changed state to \(state).")
         switch state {
         case .connecting, .connected:
             break

--- a/Sources/SpeziOmron/Devices/OmronWeightScale.swift
+++ b/Sources/SpeziOmron/Devices/OmronWeightScale.swift
@@ -80,13 +80,10 @@ public final class OmronWeightScale: BluetoothDevice, Identifiable, OmronHealthD
     private func handleCurrentTimeChange(_ time: CurrentTime) async {
         logger.debug("Received updated device time for \(self.label): \(String(describing: time))")
 
-        // TODO: pairing issue is still there
-        //  - if Bluetooth entry is removed: two notifications while one is always delivered instantly!
-        //  - if already paired in Bluetooth menu, only one notification while still connecting!
-
         // We always update time on the first current time notification. That's how it is expected for Omron devices.
         // First time notification might come before we are considered fully connected (from SpeziBluetooth point of view).
-        // However, this will trigger another notification anyways, which will then arrive once we are connected.
+        // However, this will trigger another notification anyways, which will then arrive once we are connected
+        // and the iOS Bluetooth Pairing dialog was dismissed.
         if !didReceiveFirstTimeNotification {
             didReceiveFirstTimeNotification = true
             self.time.synchronizeDeviceTime()
@@ -96,7 +93,6 @@ public final class OmronWeightScale: BluetoothDevice, Identifiable, OmronHealthD
             // for Omron we take that as a signal that device is paired
             await pairedDevices?.signalDevicePaired(self)
         }
-        // TODO: apply this changes for the blood pressure cuff as well!
     }
 }
 

--- a/Sources/SpeziOmron/Model/OmronLocalName.swift
+++ b/Sources/SpeziOmron/Model/OmronLocalName.swift
@@ -13,6 +13,9 @@ import RegexBuilder
 ///
 /// The local name is part of the advertisement sent by a Omron device.
 /// It includes additional information about the device.
+///
+/// A local name typically starts with the `BLESmart_` prefix, followed by 4 bytes of model identifier and 6 bytes of the Bluetooth Mac Address.
+/// However, if the `s` is lowercase in `BLEsmart_`, the device signals that it is advertising in pairing mode.
 public struct OmronLocalName {
     /// The pairing mode derived from the local name.
     public enum PairingMode {

--- a/Sources/SpeziOmron/SpeziOmron.docc/OmronReverseEngineering.md
+++ b/Sources/SpeziOmron/SpeziOmron.docc/OmronReverseEngineering.md
@@ -1,0 +1,44 @@
+# Reverse Engineering Omron Devices
+
+Collects knowledge acquired when reverse engineering Omron Health devices.
+
+<!--
+#
+# This source file is part of the Stanford SpeziDevices open source project
+#
+# SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+-->
+
+## Overview
+
+// TODO: what happens with unhandeled responses in Omron state machine while subscribing to characteristics?
+// TODO: omron has a connection timeout of 60s and any disonnect before that is considered a successful pairing! (do they?)
+
+- Discovery
+- Peripheral Name is the model (use that to display images)
+- 
+
+- Setting Time on first notification
+
+- When is a device considered paried
+
+Omron application considers an application paired when it disconnects and any success-indicating condition is fulfilled.
+Such conditions are:
+* A CurrentTime notification was received after sending the initial update time command.
+* Battery Level notification was received.
+* Any measurement was received (only applies to transfer mode!).
+
+// TODO: should we mention timeout of 60 seconds?
+
+- Tip: SpeziDevices improves pairing speed by not waiting for a disconnect to check these conditions, but notifying the `PairedDevices`
+    module as soon as these conditions are fulfilled, leading to a better user experience.
+
+// TODO: link paired devices module!
+
+
+// TODO: failure if wanted to read measurement and didn't
+// TODO: Failre if wanted to register new user but didn't
+// TODO: failure if registered new user but didn't recieved an updated database change increment

--- a/Sources/SpeziOmron/SpeziOmron.docc/OmronReverseEngineering.md
+++ b/Sources/SpeziOmron/SpeziOmron.docc/OmronReverseEngineering.md
@@ -14,31 +14,48 @@ Collects knowledge acquired when reverse engineering Omron Health devices.
 
 ## Overview
 
-// TODO: what happens with unhandeled responses in Omron state machine while subscribing to characteristics?
-// TODO: omron has a connection timeout of 60s and any disonnect before that is considered a successful pairing! (do they?)
+This article collects some knowledge acquired reverse engineering Omron devices when developing SpeziDevices.
 
-- Discovery
-- Peripheral Name is the model (use that to display images)
-- 
+### Discovery
 
-- Setting Time on first notification
+Omron devices are discovery by searching for their primary advertised service (e.g.,
+[`WeightScaleService`])https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetoothservices/weightscaleservice) or
+[`BloodPressureService`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetoothservices/bloodpressureservice)).
+A Omron device is either advertising in pairing mode (if you press the Bluetooth/Connection button for 3s) or in transfer mode
+(after taking a measurement or when pressing the Bluetooth/Connection button quickly).
 
-- When is a device considered paried
+> Note: If a Omron device wasn't paired you cannot enter transfer mode. Meaning pressing the Bluetooth/Connection button once doesn't do anything.
 
-Omron application considers an application paired when it disconnects and any success-indicating condition is fulfilled.
-Such conditions are:
-* A CurrentTime notification was received after sending the initial update time command.
-* Battery Level notification was received.
-* Any measurement was received (only applies to transfer mode!).
+How the Omron devices advertisings pairing mode vs. transfer mode depends on the the model. But it is one of these two methods:
+* Using the ``OmronManufacturerData/pairingMode-swift.property`` bit field of the ``OmronManufacturerData`` that is part of the advertisement.
+    Not all Omron devices include [`manufacturerData`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetooth/advertisementdata/manufacturerdata)
+    in their advertisement. In this cases use the other approach. 
+* Deriving the pairing mode from the [`localName`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetooth/advertisementdata/localname).
+    For more information see ``OmronLocalName``.
 
-// TODO: should we mention timeout of 60 seconds?
+> Tip: The name of the peripheral represents the model identifier. This can be useful to better visualize a Omron device to the user.
 
-- Tip: SpeziDevices improves pairing speed by not waiting for a disconnect to check these conditions, but notifying the `PairedDevices`
-    module as soon as these conditions are fulfilled, leading to a better user experience.
+### Time Synchronization
 
-// TODO: link paired devices module!
+Most Omron devices expose a [`CurrentTimeService`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetoothservices/currenttimeservice)
+to support timestamps in reported measurements.
+The device expects to receive updated time information when you receive the initial [`currentTime`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetoothservices/currenttimeservice/currenttime)
+notification after establishing a connection.
 
+### Pairing
 
-// TODO: failure if wanted to read measurement and didn't
-// TODO: Failre if wanted to register new user but didn't
-// TODO: failure if registered new user but didn't recieved an updated database change increment
+While you can initiate pairing with a device that is advertising in transfer mode, it makes sense to filter for nearby devices in pairing mode
+to avoid accidental connections.
+
+Omron application considers an application paired when the device disconnects and any success-indicating condition is fulfilled.
+Such conditions are the following events if they happen once the device is fully connected (fully discovered and **subscribed to all relevant characteristics**):
+* A [`currentTime`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetoothservices/currenttimeservice/currenttime) notification was received
+    (make sure you comply with <doc:#Time-Synchronization> requirements).
+* A [`batteryLevel`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/2.0.2/documentation/spezibluetoothservices/batteryservice/batterylevel) notification was received.
+
+- Tip: SpeziDevices improves pairing speed by not waiting for a disconnect to check these conditions, but notifying the [`PairedDevices`](https://swiftpackageindex.com/stanfordspezi/spezidevices/documentation/spezidevices/paireddevices)
+module as soon as these conditions are fulfilled, leading to a better user experience.
+
+### Transfer
+
+A Omron device will automatically indicate the measurement characteristic with new measurements once it is connected to the paired device.

--- a/Sources/SpeziOmron/SpeziOmron.docc/OmronReverseEngineering.md
+++ b/Sources/SpeziOmron/SpeziOmron.docc/OmronReverseEngineering.md
@@ -26,8 +26,8 @@ A Omron device is either advertising in pairing mode (if you press the Bluetooth
 
 > Note: If a Omron device wasn't paired you cannot enter transfer mode. Meaning pressing the Bluetooth/Connection button once doesn't do anything.
 
-How the Omron devices advertisings pairing mode vs. transfer mode depends on the the model. But it is one of these two methods:
-* Using the ``OmronManufacturerData/pairingMode-swift.property`` bit field of the ``OmronManufacturerData`` that is part of the advertisement.
+If the Omron device advertising pairing mode vs. transfer mode, depends on the the device model. It uses one of these two methods:
+* Using the ``OmronManufacturerData/pairingMode-swift.property`` bit field of the ``OmronManufacturerData`` which is part of the advertisement data.
     Not all Omron devices include [`manufacturerData`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetooth/advertisementdata/manufacturerdata)
     in their advertisement. In this cases use the other approach. 
 * Deriving the pairing mode from the [`localName`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetooth/advertisementdata/localname).

--- a/Sources/SpeziOmron/SpeziOmron.docc/SpeziOmron.md
+++ b/Sources/SpeziOmron/SpeziOmron.docc/SpeziOmron.md
@@ -55,6 +55,7 @@ class ExampleAppDelegate: SpeziAppDelegate {
 
 - ``OmronBloodPressureCuff``
 - ``OmronWeightScale``
+- <doc:OmronReverseEngineering>
 
 ### Omron Device
 

--- a/Tests/SpeziDevicesTests/HealthMeasurementsTests.swift
+++ b/Tests/SpeziDevicesTests/HealthMeasurementsTests.swift
@@ -14,6 +14,9 @@ import XCTest
 
 
 final class HealthMeasurementsTests: XCTestCase {
+    // TODO: add regression tests: discard measurements while connecting
+    // TODO: add Omron tests for the time notifications/time synchronization!
+
     @MainActor
     func testReceivingWeightMeasurements() async throws {
         let device = MockDevice.createMockDevice(state: .connected, weightMeasurement: .mock(additionalInfo: .init(bmi: 230, height: 1790)))

--- a/Tests/SpeziDevicesTests/HealthMeasurementsTests.swift
+++ b/Tests/SpeziDevicesTests/HealthMeasurementsTests.swift
@@ -14,18 +14,17 @@ import XCTest
 
 
 final class HealthMeasurementsTests: XCTestCase {
-    // TODO: add regression tests: discard measurements while connecting
-    // TODO: add Omron tests for the time notifications/time synchronization!
-
     @MainActor
     func testReceivingWeightMeasurements() async throws {
-        let device = MockDevice.createMockDevice(state: .connected, weightMeasurement: .mock(additionalInfo: .init(bmi: 230, height: 1790)))
+        let device = MockDevice.createMockDevice(state: .connecting, weightMeasurement: .mock(additionalInfo: .init(bmi: 230, height: 1790)))
         let measurements = HealthMeasurements()
 
         measurements.configureReceivingMeasurements(for: device, on: \.weightScale)
 
         // just inject the same value again to trigger on change!
         let measurement = try XCTUnwrap(device.weightScale.weightMeasurement)
+        device.weightScale.$weightMeasurement.inject(measurement) // first measurement should be ignored in connecting state!
+        device.$state.inject(.connected)
         device.weightScale.$weightMeasurement.inject(measurement)
 
         try await Task.sleep(for: .milliseconds(50))

--- a/Tests/SpeziDevicesTests/HealthMeasurementsTests.swift
+++ b/Tests/SpeziDevicesTests/HealthMeasurementsTests.swift
@@ -16,7 +16,7 @@ import XCTest
 final class HealthMeasurementsTests: XCTestCase {
     @MainActor
     func testReceivingWeightMeasurements() async throws {
-        let device = MockDevice.createMockDevice(weightMeasurement: .mock(additionalInfo: .init(bmi: 230, height: 1790)))
+        let device = MockDevice.createMockDevice(state: .connected, weightMeasurement: .mock(additionalInfo: .init(bmi: 230, height: 1790)))
         let measurements = HealthMeasurements()
 
         measurements.configureReceivingMeasurements(for: device, on: \.weightScale)
@@ -64,7 +64,7 @@ final class HealthMeasurementsTests: XCTestCase {
 
     @MainActor
     func testReceivingBloodPressureMeasurements() async throws {
-        let device = MockDevice.createMockDevice()
+        let device = MockDevice.createMockDevice(state: .connected)
         let measurements = HealthMeasurements()
 
         measurements.configureReceivingMeasurements(for: device, on: \.bloodPressure)
@@ -141,7 +141,7 @@ final class HealthMeasurementsTests: XCTestCase {
 
     @MainActor
     func testDiscardingMeasurements() async throws {
-        let device = MockDevice.createMockDevice()
+        let device = MockDevice.createMockDevice(state: .connected)
         let measurements = HealthMeasurements()
 
         measurements.configureReceivingMeasurements(for: device, on: \.bloodPressure)

--- a/Tests/SpeziDevicesTests/HealthMeasurementsTests.swift
+++ b/Tests/SpeziDevicesTests/HealthMeasurementsTests.swift
@@ -24,6 +24,8 @@ final class HealthMeasurementsTests: XCTestCase {
         // just inject the same value again to trigger on change!
         let measurement = try XCTUnwrap(device.weightScale.weightMeasurement)
         device.weightScale.$weightMeasurement.inject(measurement) // first measurement should be ignored in connecting state!
+
+        try await Task.sleep(for: .milliseconds(50))
         device.$state.inject(.connected)
         device.weightScale.$weightMeasurement.inject(measurement)
 

--- a/Tests/UITests/TestAppUITests/BluetoothViewsTests.swift
+++ b/Tests/UITests/TestAppUITests/BluetoothViewsTests.swift
@@ -46,8 +46,7 @@ class BluetoothViewsTests: XCTestCase {
         app.buttons["Open Settings"].tap()
 
         let settingsApp = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
-        try await Task.sleep(for: .seconds(2))
-        XCTAssertEqual(settingsApp.state, .runningForeground)
+        XCTAssertTrue(settingsApp.wait(for: .runningForeground, timeout: 2.0))
     }
 
     @MainActor

--- a/Tests/UITests/TestAppUITests/HealthMeasurementsTests.swift
+++ b/Tests/UITests/TestAppUITests/HealthMeasurementsTests.swift
@@ -144,9 +144,5 @@ class HealthMeasurementsTests: XCTestCase {
 
         XCTAssert(app.buttons["Discard"].waitForExistence(timeout: 0.5))
         app.buttons["Discard"].tap()
-
-        XCTAssert(app.staticTexts["No Pending Measurements"].waitForExistence(timeout: 2.0))
-        XCTAssert(app.navigationBars.buttons["Dismiss"].exists)
-        app.navigationBars.buttons["Dismiss"].tap()
     }
 }


### PR DESCRIPTION
# Fix duplicated delivery of Omron Measurements

## :recycle: Current situation & Problem
This PR fixes some minor issues with the current implementation of Omron devices.  https://github.com/StanfordSpezi/SpeziBluetooth/pull/46 made two important changes to improve the overall reliability of the implementation. First, it fixes an issue with notify-only characteristics (like weight and blood pressure measurement characteristics) where the `onChange` would not be called. Secondly, while the device is subscribing to characteristic notifications, the state is still set to `connecting`, this allows us to properly filter the initial measurement notifications that Omron devices send when subscribing to characteristics. Further, this allowed us to fix an issue where we couldn't properly determine the point in time where a weight scale was fully paired by the user.

Additionally this PR adds a small time label for the `MeasurementsRecordedSheet` and adds German localization.

## :gear: Release Notes 
* Fixed duplicated deliver of measurements for Omron devices.
* Fixed pairing with Omron weight scales.
* Added a time label to the `MeasurementsRecordedSheet`.
* Added German localization.

## :books: Documentation
Added a small documentation article that collects knowledge about Omron devices.


## :white_check_mark: Testing
We used manual testing with real Omron devices to verify the implementation. Some additional unit tests were added to ensure no regression occur.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
