### PR TITLE
Bump XCTestExtensions to 1.0 release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,9 +36,9 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.5.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", from: "3.0.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", branch: "fix/bump-test-extensions"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "2.1.1"),
-        .package(url: "https://github.com/StanfordBDHG/XCTestExtensions", .upToNextMinor(from: "0.4.12"))
+        .package(url: "https://github.com/StanfordBDHG/XCTestExtensions", from: "1.0.0")
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.1"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.5.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", branch: "fix/bump-test-extensions"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", from: "3.0.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "2.1.1"),
         .package(url: "https://github.com/StanfordBDHG/XCTestExtensions", from: "1.0.0")
     ] + swiftLintPackage(),

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -722,8 +722,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordBDHG/XCTestExtensions.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.11;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
# Bump XCTestExtensions to 1.0 release

## :recycle: Current situation & Problem
This PR bumps the `XCTestExtensions` dependency to the latest stable release.


## :gear: Release Notes 
* Bump XCTestExtensions to 1.0 release


## :books: Documentation
--


## :white_check_mark: Testing
not affected

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
