### PR TITLE
Only dismiss the measurements sheet when we are saving the last one

### DIFF
--- a/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
+++ b/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
@@ -65,7 +65,7 @@ public struct MeasurementsRecordedSheet: View {
     public var body: some View {
         NavigationStack {
             Group {
-                if measurements.pendingMeasurements.isEmpty {
+                if measurements.pendingMeasurements.isEmpty && selectedMeasurement == nil {
                     ContentUnavailableView(
                         "No Pending Measurements",
                         systemImage: "heart.text.square",
@@ -120,7 +120,7 @@ public struct MeasurementsRecordedSheet: View {
             }
                 .tabViewStyle(.page)
                 .indexViewStyle(.page(backgroundDisplayMode: .always))
-        } else if let measurement = measurements.pendingMeasurements.first {
+        } else if let measurement = selectedMeasurement {
             MeasurementLayer(measurement: measurement)
         }
     }
@@ -165,10 +165,13 @@ public struct MeasurementsRecordedSheet: View {
         }
 
         measurements.discardMeasurement(measurement)
-        if index >= measurements.pendingMeasurements.count {
-            selectedMeasurement = measurements.pendingMeasurements.last
-        } else {
+
+        if index < measurements.pendingMeasurements.count {
             selectedMeasurement = measurements.pendingMeasurements[index]
+        } else if let last = measurements.pendingMeasurements.last {
+            // we do not set `selectedMeasurement` to nil if we are discarding the last measurement to have the
+            // last measurement still display when the sheet is in its dismiss animation.
+            selectedMeasurement = last
         }
 
         if measurements.pendingMeasurements.isEmpty {
@@ -180,8 +183,9 @@ public struct MeasurementsRecordedSheet: View {
 
 #if DEBUG
 #Preview {
-    Text(verbatim: "")
-        .sheet(isPresented: .constant(true)) {
+    @State var isPresented = true
+    return Text(verbatim: "")
+        .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
                 print("Saving samples \(samples)")
             }
@@ -192,8 +196,9 @@ public struct MeasurementsRecordedSheet: View {
 }
 
 #Preview {
-    Text(verbatim: "")
-        .sheet(isPresented: .constant(true)) {
+    @State var isPresented = true
+    return Text(verbatim: "")
+        .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
                 print("Saving samples \(samples)")
             }
@@ -204,8 +209,9 @@ public struct MeasurementsRecordedSheet: View {
 }
 
 #Preview {
-    Text(verbatim: "")
-        .sheet(isPresented: .constant(true)) {
+    @State var isPresented = true
+    return Text(verbatim: "")
+        .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
                 print("Saving samples \(samples)")
             }
@@ -216,8 +222,9 @@ public struct MeasurementsRecordedSheet: View {
 }
 
 #Preview {
-    Text(verbatim: "")
-        .sheet(isPresented: .constant(true)) {
+    @State var isPresented = true
+    return Text(verbatim: "")
+        .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
                 print("Saving samples \(samples)")
             }
@@ -232,8 +239,9 @@ public struct MeasurementsRecordedSheet: View {
 }
 
 #Preview {
-    Text(verbatim: "")
-        .sheet(isPresented: .constant(true)) {
+    @State var isPresented = true
+    return Text(verbatim: "")
+        .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
                 print("Saving samples \(samples)")
             }

--- a/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
+++ b/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
@@ -140,7 +140,6 @@ public struct MeasurementsRecordedSheet: View {
 
 
             logger.info("Saved measurement: \(String(describing: selectedMeasurement))")
-            dismiss()
 
             discardSelectedMeasurement(selectedMeasurement)
         } discard: {
@@ -149,10 +148,6 @@ public struct MeasurementsRecordedSheet: View {
             }
 
             discardSelectedMeasurement(selectedMeasurement)
-
-            if measurements.pendingMeasurements.isEmpty {
-                dismiss()
-            }
         }
     }
 
@@ -174,6 +169,10 @@ public struct MeasurementsRecordedSheet: View {
             selectedMeasurement = measurements.pendingMeasurements.last
         } else {
             selectedMeasurement = measurements.pendingMeasurements[index]
+        }
+
+        if measurements.pendingMeasurements.isEmpty {
+            dismiss()
         }
     }
 }


### PR DESCRIPTION
# Only dismiss the measurements sheet when we are saving the last one

## :recycle: Current situation & Problem
This PR address https://github.com/StanfordBDHG/ENGAGE-HF-iOS/issues/79 by only dismissing the recorded measurements sheet only if there aren't any more measurements displayed. This makes it easier for users to save multiple measurements.

## :gear: Release Notes 
* Only dismiss the measurements sheet if the last measurement is saved.
*  Show the last measurement in the closing animation.

## :books: Documentation
--


## :white_check_mark: Testing
Existing test validate this behavior.

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
