### PR TITLE
Allow to customize the measurements loaded with testing support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -33,16 +33,6 @@ jobs:
       scheme: TestApp
       resultBundle: TestApp-iOS.xcresult
       artifactname: TestApp-iOS.xcresult
-  codeql:
-    name: CodeQL
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      codeql: true
-      test: false
-      scheme: SpeziDevices-Package
-    permissions:
-      security-events: write
-      actions: read
   uploadcoveragereport:
     name: Upload Coverage Report
     needs: [packageios, ios]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,16 +24,6 @@ jobs:
       scheme: SpeziDevices-Package
       resultBundle: SpeziDevices-iOS.xcresult
       artifactname: SpeziDevices-iOS.xcresult
-  packageios_latest:
-    name: Build and Test Swift Package iOS Latest
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      scheme: SpeziDevices-Package
-      xcodeversion: latest
-      swiftVersion: 6
-      resultBundle: SpeziDevices-iOS-Latest.xcresult
-      artifactname: SpeziDevices-iOS-Latest.xcresult
   ios:
     name: Build and Test iOS
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
@@ -43,17 +33,6 @@ jobs:
       scheme: TestApp
       resultBundle: TestApp-iOS.xcresult
       artifactname: TestApp-iOS.xcresult
-  ios_latest:
-    name: Build and Test iOS Latest
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      path: 'Tests/UITests'
-      scheme: TestApp
-      xcodeversion: latest
-      swiftVersion: 6
-      resultBundle: TestApp-iOS-Latest.xcresult
-      artifactname: TestApp-iOS-Latest.xcresult
   codeql:
     name: CodeQL
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 //
 // This source file is part of the Stanford SpeziDevices open source project
@@ -10,13 +10,6 @@
 
 import class Foundation.ProcessInfo
 import PackageDescription
-
-
-#if swift(<6)
-let swiftConcurrency: SwiftSetting = .enableExperimentalFeature("StrictConcurrency")
-#else
-let swiftConcurrency: SwiftSetting = .enableUpcomingFeature("StrictConcurrency")
-#endif
 
 
 let package = Package(
@@ -51,10 +44,6 @@ let package = Package(
                 .product(name: "SpeziViews", package: "SpeziViews"),
                 .product(name: "Spezi", package: "Spezi")
             ],
-            swiftSettings: [
-                swiftConcurrency,
-                .enableUpcomingFeature("InferSendableFromCaptures")
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -68,10 +57,6 @@ let package = Package(
             resources: [
                 .process("Resources")
             ],
-            swiftSettings: [
-                swiftConcurrency,
-                .enableUpcomingFeature("InferSendableFromCaptures")
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .target(
@@ -83,10 +68,6 @@ let package = Package(
             ],
             resources: [
                 .process("Resources")
-            ],
-            swiftSettings: [
-                swiftConcurrency,
-                .enableUpcomingFeature("InferSendableFromCaptures")
             ],
             plugins: [] + swiftLintPlugin()
         ),
@@ -100,10 +81,6 @@ let package = Package(
                 .product(name: "SpeziBluetoothServices", package: "SpeziBluetooth"),
                 .product(name: "XCTestExtensions", package: "XCTestExtensions")
             ],
-            swiftSettings: [
-                swiftConcurrency,
-                .enableUpcomingFeature("InferSendableFromCaptures")
-            ],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -113,10 +90,6 @@ let package = Package(
                 .product(name: "SpeziBluetooth", package: "SpeziBluetooth"),
                 .product(name: "XCTByteCoding", package: "SpeziNetworking"),
                 .product(name: "XCTestExtensions", package: "XCTestExtensions")
-            ],
-            swiftSettings: [
-                swiftConcurrency,
-                .enableUpcomingFeature("InferSendableFromCaptures")
             ],
             plugins: [] + swiftLintPlugin()
         )

--- a/Package.swift
+++ b/Package.swift
@@ -32,13 +32,13 @@ let package = Package(
         .library(name: "SpeziOmron", targets: ["SpeziOmron"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-collections", from: "1.1.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "2.0.0-beta.1"),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.7.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.5.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth", from: "3.0.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "2.1.1"),
-        .package(url: "https://github.com/StanfordBDHG/XCTestExtensions", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.7.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziViews.git", from: "1.5.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziBluetooth.git", from: "3.0.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking.git", from: "2.1.1"),
+        .package(url: "https://github.com/StanfordBDHG/XCTestExtensions.git", from: "1.0.0")
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Sources/SpeziDevices/HealthMeasurements.swift
+++ b/Sources/SpeziDevices/HealthMeasurements.swift
@@ -334,10 +334,22 @@ extension HealthMeasurements {
     /// Call in preview simulator wrappers.
     ///
     /// Loads a mock measurement to display in preview.
+    /// - Parameters:
+    ///   - weightMeasurement: The weight measurement that should be loaded.
+    ///   - weightResolution: The weight resolution to use.
+    ///   - heightResolution: The height resolution to use.
     @_spi(TestingSupport)
     @MainActor
-    public func loadMockWeightMeasurement() {
-        let device = MockDevice.createMockDevice()
+    public func loadMockWeightMeasurement(
+        weightMeasurement: WeightMeasurement = .mock(),
+        weightResolution: WeightScaleFeature.WeightResolution = .resolution5g,
+        heightResolution: WeightScaleFeature.HeightResolution = .resolution1mm
+    ) {
+        let device = MockDevice.createMockDevice(
+            weightMeasurement: weightMeasurement,
+            weightResolution: weightResolution,
+            heightResolution: heightResolution
+        )
 
         guard let measurement = device.weightScale.weightMeasurement else {
             preconditionFailure("Mock Weight Measurement was never injected!")
@@ -349,10 +361,11 @@ extension HealthMeasurements {
     /// Call in preview simulator wrappers.
     ///
     /// Loads a mock measurement to display in preview.
+    /// - Parameter bloodPressureMeasurement: The blood pressure measurement that should be loaded.
     @_spi(TestingSupport)
     @MainActor
-    public func loadMockBloodPressureMeasurement() {
-        let device = MockDevice.createMockDevice()
+    public func loadMockBloodPressureMeasurement(bloodPressureMeasurement: BloodPressureMeasurement = .mock()) {
+        let device = MockDevice.createMockDevice(bloodPressureMeasurement: bloodPressureMeasurement)
 
         guard let measurement = device.bloodPressure.bloodPressureMeasurement else {
             preconditionFailure("Mock Blood Pressure Measurement was never injected!")

--- a/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
+++ b/Sources/SpeziDevicesUI/Measurements/MeasurementsRecordedSheet.swift
@@ -183,7 +183,7 @@ public struct MeasurementsRecordedSheet: View {
 
 #if DEBUG
 #Preview {
-    @State var isPresented = true
+    @State @Previewable var isPresented = true
     return Text(verbatim: "")
         .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
@@ -196,7 +196,7 @@ public struct MeasurementsRecordedSheet: View {
 }
 
 #Preview {
-    @State var isPresented = true
+    @State @Previewable var isPresented = true
     return Text(verbatim: "")
         .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
@@ -209,7 +209,7 @@ public struct MeasurementsRecordedSheet: View {
 }
 
 #Preview {
-    @State var isPresented = true
+    @State @Previewable var isPresented = true
     return Text(verbatim: "")
         .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
@@ -222,7 +222,7 @@ public struct MeasurementsRecordedSheet: View {
 }
 
 #Preview {
-    @State var isPresented = true
+    @State @Previewable var isPresented = true
     return Text(verbatim: "")
         .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in
@@ -239,7 +239,7 @@ public struct MeasurementsRecordedSheet: View {
 }
 
 #Preview {
-    @State var isPresented = true
+    @State @Previewable var isPresented = true
     return Text(verbatim: "")
         .sheet(isPresented: $isPresented) {
             MeasurementsRecordedSheet { samples in

--- a/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
+++ b/Sources/SpeziOmron/Devices/OmronBloodPressureCuff.swift
@@ -129,6 +129,7 @@ extension OmronBloodPressureCuff {
     ///   - state: The initial state.
     ///   - nearby: The nearby state.
     ///   - manufacturerData: The initial manufacturer data.
+    ///   - timeStamp: The timestamp of the latest measurement.
     ///   - simulateRealDevice: If `true`, the real onChange handlers with be set up with the mock device.
     /// - Returns: Returns the mock device instance.
     public static func createMockDevice( // swiftlint:disable:this function_body_length
@@ -141,6 +142,7 @@ extension OmronBloodPressureCuff {
         manufacturerData: OmronManufacturerData = OmronManufacturerData(pairingMode: .pairingMode, users: [
             .init(id: 1, sequenceNumber: 2, recordsNumber: 1)
         ]),
+        timeStamp: DateTime = DateTime(year: 2024, month: .june, day: 5, hours: 12, minutes: 33, seconds: 11),
         simulateRealDevice: Bool = false
     ) -> OmronBloodPressureCuff {
         let device = OmronBloodPressureCuff()
@@ -167,7 +169,7 @@ extension OmronBloodPressureCuff {
             diastolic: diastolic,
             meanArterialPressure: 77,
             unit: .mmHg,
-            timeStamp: DateTime(year: 2024, month: .june, day: 5, hours: 12, minutes: 33, seconds: 11),
+            timeStamp: timeStamp,
             pulseRate: pulseRate,
             userId: 1,
             measurementStatus: []

--- a/Sources/SpeziOmron/Devices/OmronWeightScale.swift
+++ b/Sources/SpeziOmron/Devices/OmronWeightScale.swift
@@ -107,6 +107,7 @@ extension OmronWeightScale {
     ///   - state: The initial state.
     ///   - nearby: The nearby state.
     ///   - manufacturerData: The initial manufacturer data.
+    ///   - timeStamp: The timestamp of the latest measurement.
     ///   - simulateRealDevice: If `true`, the real onChange handlers with be set up with the mock device.
     /// - Returns: Returns the mock device instance.
     public static func createMockDevice( // swiftlint:disable:this function_body_length
@@ -117,6 +118,7 @@ extension OmronWeightScale {
         manufacturerData: OmronManufacturerData = OmronManufacturerData(pairingMode: .pairingMode, users: [
             .init(id: 1, sequenceNumber: 2, recordsNumber: 1)
         ]),
+        timeStamp: DateTime = DateTime(year: 2024, month: .june, day: 5, hours: 12, minutes: 33, seconds: 11),
         simulateRealDevice: Bool = false
     ) -> OmronWeightScale {
         let device = OmronWeightScale()
@@ -140,7 +142,8 @@ extension OmronWeightScale {
 
         let measurement = WeightMeasurement(
             weight: weight,
-            unit: .si
+            unit: .si,
+            timeStamp: timeStamp
         )
 
         device.weightScale.$features.inject(features)

--- a/Tests/SpeziOmronTests/SpeziOmronTests.swift
+++ b/Tests/SpeziOmronTests/SpeziOmronTests.swift
@@ -246,8 +246,4 @@ final class SpeziOmronTests: XCTestCase {
 }
 
 
-#if compiler(<6)
-extension SpeziDevices.MockDevice: SpeziOmron.OmronHealthDevice {}
-#else
-extension MockDevice: @retroactive OmronHealthDevice {}
-#endif
+extension MockDevice: OmronHealthDevice {}

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -220,7 +220,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					2F6D139128F5F384007C25D6 = {
 						CreatedOnToolsVersion = 14.1;
@@ -232,7 +232,6 @@
 				};
 			};
 			buildConfigurationList = 2F6D138D28F5F384007C25D6 /* Build configuration list for PBXProject "UITests" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -243,6 +242,7 @@
 			packageReferences = (
 				A959B7F12C2D646500ACA775 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 			);
+			preferredProjectObjectVersion = 77;
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -371,6 +371,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 				TVOS_DEPLOYMENT_TARGET = 17.0;
 				WATCHOS_DEPLOYMENT_TARGET = 10.0;
 				XROS_DEPLOYMENT_TARGET = 1.0;
@@ -431,6 +432,7 @@
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 				TVOS_DEPLOYMENT_TARGET = 17.0;
 				VALIDATE_PRODUCT = YES;
 				WATCHOS_DEPLOYMENT_TARGET = 10.0;
@@ -441,7 +443,6 @@
 		2F6D13B728F5F386007C25D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -477,7 +478,6 @@
 		2F6D13B828F5F386007C25D6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -513,7 +513,6 @@
 		2F6D13BD28F5F386007C25D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -536,7 +535,6 @@
 		2F6D13BE28F5F386007C25D6 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -617,6 +615,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = TEST;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_STRICT_CONCURRENCY = complete;
+				SWIFT_VERSION = 6.0;
 				TVOS_DEPLOYMENT_TARGET = 17.0;
 				WATCHOS_DEPLOYMENT_TARGET = 10.0;
 				XROS_DEPLOYMENT_TARGET = 1.0;
@@ -626,7 +625,6 @@
 		2FB07588299DDB6000C0B37F /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -662,7 +660,6 @@
 		2FB07589299DDB6000C0B37F /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1600"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
# Allow to customize the measurements loaded with testing support

## :recycle: Current situation & Problem
Previously, we used a fixed, default timestamp when creating the current measurement values for Omron Mock devices (we didn't even specify a timestamp with the weight scale). This PR improves this mechanism by allowing to specify a custom time and allowing to specify a time for the weight scale at all.

## :gear: Release Notes 
* Added new `timeStamp` parameter when creating Omron mock devices.


## :books: Documentation
Updated.

## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
