### PR TITLE
Fix primary color of nearby device row

### DIFF
--- a/Sources/SpeziDevicesUI/Measurements/ConfirmMeasurementButton.swift
+++ b/Sources/SpeziDevicesUI/Measurements/ConfirmMeasurementButton.swift
@@ -33,7 +33,7 @@ struct DiscardButton: View {
 
 
 struct ConfirmMeasurementButton: View {
-    private let confirm: () async throws -> Void
+    private let confirm: @MainActor () async throws -> Void
     private let discard: () -> Void
 
     @ScaledMetric private var buttonHeight: CGFloat = 38
@@ -55,7 +55,7 @@ struct ConfirmMeasurementButton: View {
         }
     }
 
-    init(viewState: Binding<ViewState>, confirm: @escaping () async throws -> Void, discard: @escaping () -> Void) {
+    init(viewState: Binding<ViewState>, confirm: @escaping @MainActor () async throws -> Void, discard: @escaping () -> Void) {
         self._viewState = viewState
         self.confirm = confirm
         self.discard = discard

--- a/Sources/SpeziDevicesUI/Scanning/NearbyDeviceRow.swift
+++ b/Sources/SpeziDevicesUI/Scanning/NearbyDeviceRow.swift
@@ -46,6 +46,7 @@ public struct NearbyDeviceRow: View {
                 HStack {
                     ListRow(verbatim: peripheral.label) {
                         deviceSecondaryLabel
+                            .foregroundStyle(.secondary)
                     }
                     if peripheral.state == .connecting || peripheral.state == .disconnecting {
                         ProgressView()
@@ -53,6 +54,7 @@ public struct NearbyDeviceRow: View {
                     }
                 }
             }
+                .foregroundStyle(.primary)
 
             if showDetailsButton {
                 Button(action: deviceDetailsAction) {


### PR DESCRIPTION
# Fix primary color of nearby device row

## :recycle: Current situation & Problem
Slight styling adjustments. Due to the button the device name was rendered in the accent color. This fixes the label to be primary color again.


## :gear: Release Notes 
* Fixed appearance of nearby device row.


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
